### PR TITLE
fix(setup): invalid binary sensor value assignement

### DIFF
--- a/custom_components/cowboy/binary_sensor.py
+++ b/custom_components/cowboy/binary_sensor.py
@@ -76,7 +76,7 @@ class CowboyBinarySensor(CowboyBikeCoordinatedEntity, BinarySensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._attr_is_on = self.entity_description.attrs(self.coordinator.data)
+        self._attr_is_on = self.coordinator.data[self.entity_description.key]
         self.async_write_ha_state()
 
 

--- a/custom_components/cowboy/binary_sensor.py
+++ b/custom_components/cowboy/binary_sensor.py
@@ -26,6 +26,12 @@ SENSOR_TYPES: tuple[CowboySensorEntityDescription, ...] = (
         icon="mdi:alert",
         device_class=BinarySensorDeviceClass.SAFETY,
     ),
+    CowboySensorEntityDescription(
+        key="battery_inserted",
+        translation_key="battery_inserted",
+        icon="mdi:battery",
+        device_class=BinarySensorDeviceClass.PLUG,
+    )
 )
 
 

--- a/custom_components/cowboy/strings.json
+++ b/custom_components/cowboy/strings.json
@@ -50,6 +50,9 @@
       },
       "update_available": {
         "name": "Update available"
+      },
+      "battery_inserted": {
+          "name": "Battery"
       }
     }
   }

--- a/custom_components/cowboy/translations/en.json
+++ b/custom_components/cowboy/translations/en.json
@@ -27,6 +27,9 @@
             },
             "update_available": {
                 "name": "Update available"
+            },
+            "battery_inserted": {
+                "name": "Battery"
             }
         },
         "sensor": {

--- a/custom_components/cowboy/translations/pt.json
+++ b/custom_components/cowboy/translations/pt.json
@@ -27,6 +27,9 @@
             },
             "update_available": {
                 "name": "Atualização disponível"
+            },
+            "battery_inserted": {
+                "name": "Batteria"
             }
         },
         "sensor": {


### PR DESCRIPTION
Problem:

Binary sensors where always set to false due to an error in the fetching of the value.
The fix should make it now synced with values from the backend.

Testable by setting the bike in the app to "stolen" by using "Find my Bike", the result should sync with Home Assistant within a minute