### PR TITLE
Add new battery state binary sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Among others, the following sensors are available:
 - **Remaining Range**: Indicates the estimated remaining range.
 - **Battery Level Sensor**: Monitors the current battery status.
 - **Battery Health**: Gives an indication of the battery's health.
+- **Battery Docked**: Weither or not the battery is inside the bike
 - **Usage Duration**: Tracks the total usage duration of the bike.
 - **Software Update Alerts**: Notifies you of available software updates for your bike.
 - **Location Tracking**: Tracks the current position of your Cowboy bike.

--- a/custom_components/cowboy/binary_sensor.py
+++ b/custom_components/cowboy/binary_sensor.py
@@ -26,6 +26,12 @@ SENSOR_TYPES: tuple[CowboySensorEntityDescription, ...] = (
         icon="mdi:alert",
         device_class=BinarySensorDeviceClass.SAFETY,
     ),
+    CowboySensorEntityDescription(
+        key="battery_inserted",
+        translation_key="battery_inserted",
+        icon="mdi:battery",
+        device_class=BinarySensorDeviceClass.PLUG,
+    )
 )
 
 

--- a/custom_components/cowboy/strings.json
+++ b/custom_components/cowboy/strings.json
@@ -50,6 +50,9 @@
       },
       "update_available": {
         "name": "Update available"
+      },
+      "battery_inserted": {
+          "name": "Battery"
       }
     }
   }

--- a/custom_components/cowboy/translations/en.json
+++ b/custom_components/cowboy/translations/en.json
@@ -27,6 +27,9 @@
             },
             "update_available": {
                 "name": "Update available"
+            },
+            "battery_inserted": {
+                "name": "Battery"
             }
         },
         "sensor": {

--- a/custom_components/cowboy/translations/pt.json
+++ b/custom_components/cowboy/translations/pt.json
@@ -27,6 +27,9 @@
             },
             "update_available": {
                 "name": "Atualização disponível"
+            },
+            "battery_inserted": {
+                "name": "Bateria"
             }
         },
         "sensor": {


### PR DESCRIPTION
Introduce a binary sensor for detecting the battery state, including relevant translations and icon updates.

This new field was added recently and gives the state of the battery plugged/unplugged