### PR TITLE
feat: use ride mode-specific autonomy for range calculation

### DIFF
--- a/custom_components/cowboy/sensor.py
+++ b/custom_components/cowboy/sensor.py
@@ -75,7 +75,12 @@ SENSOR_TYPES: tuple[CowboySensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DISTANCE,
         suggested_display_precision=0,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data['battery_state_of_charge'] / 100 * data['autonomy'],
+        value_fn=lambda data: data['battery_state_of_charge'] / 100 * (
+            next(
+                (autonomy['full_battery_range'] for autonomy in data.get('autonomies', []) if autonomy['ride_mode'] == data.get('last_ride_mode')),
+                data.get('autonomy', 0)
+            )
+        ),
     ),
     CowboySensorEntityDescription(
         key="battery_health",


### PR DESCRIPTION
Calculate remaining range using the full_battery_range from the autonomies array matching the last_ride_mode. This provides more accurate range estimates based on the actual riding mode (e.g., Eco vs Adaptive mode).

Fallback to the generic autonomy value if last_ride_mode is not available, maintaining backward compatibility.

Fixes #112

---
Generated with [Claude Code](https://claude.ai/code)