### PR TITLE
fix: recover authentication sessions

### DIFF
--- a/custom_components/cowboy/_client.py
+++ b/custom_components/cowboy/_client.py
@@ -1,4 +1,5 @@
 import time
+from threading import RLock
 
 import requests
 
@@ -14,6 +15,7 @@ class CowboyAPIClient:
         self.uid = None
         self.client = None
         self.token_expires = None
+        self._request_lock = RLock()
 
         # When bike_id is provided, all per-bike endpoints use it regardless of
         # which bike happens to be active in the login response. When it's
@@ -21,42 +23,41 @@ class CowboyAPIClient:
         self.bike_id = bike_id
 
     def login(self, email, password):
-        self.email = email
-        self.password = password
-        url = f"{self.base_url}/auth/sign_in"
-        headers = {
-            "content-type": "application/json",
-            "X-Cowboy-App-Token": self.app_token,
-            "Client-Type": self.client_type,
-        }
-        payload = {"email": email, "password": password}
-        response = requests.post(url, json=payload, headers=headers, timeout=10)
-        response.raise_for_status()
+        with self._request_lock:
+            self.email = email
+            self.password = password
+            url = f"{self.base_url}/auth/sign_in"
+            headers = {
+                "content-type": "application/json",
+                "X-Cowboy-App-Token": self.app_token,
+                "Client-Type": self.client_type,
+            }
+            payload = {"email": email, "password": password}
+            response = requests.post(url, json=payload, headers=headers, timeout=10)
+            response.raise_for_status()
+            self._update_session(response)
 
-        self.access_token = response.headers.get("Access-Token")
-        self.uid = response.headers.get("Uid")
-        self.client = response.headers.get("Client")
-        self.token_expires = int(response.headers.get("Expiry"))
+            json_response = response.json()
 
-        json_response = response.json()
+            if self.bike_id is None:
+                self.bike_id = json_response["data"]["bike"]["id"]
 
-        if self.bike_id is None:
-            self.bike_id = json_response["data"]["bike"]["id"]
+            return json_response
 
-        return json_response
+    def _update_session(self, response):
+        """Update authentication details returned by the API."""
+        if access_token := response.headers.get("Access-Token"):
+            self.access_token = access_token
+        if uid := response.headers.get("Uid"):
+            self.uid = uid
+        if client := response.headers.get("Client"):
+            self.client = client
+        if expiry := response.headers.get("Expiry"):
+            self.token_expires = int(expiry)
 
-    def _is_token_expired(self):
-        current_time = int(time.time())
-        return current_time >= self.token_expires
-
-    def _renew_token(self):
-        self.login(self.email, self.password)
-
-    def logout(self):
-        if not self.access_token or not self.uid or not self.client:
-            raise ValueError("Not logged in")
-        url = f"{self.base_url}/auth/sign_out"
-        headers = {
+    def _auth_headers(self):
+        """Return authentication headers for an API request."""
+        return {
             "content-type": "application/json",
             "X-Cowboy-App-Token": self.app_token,
             "Access-Token": self.access_token,
@@ -64,9 +65,24 @@ class CowboyAPIClient:
             "Uid": self.uid,
             "Client": self.client,
         }
-        response = requests.delete(url, headers=headers, timeout=5)
-        response.raise_for_status()
-        return response.json()
+
+    def _is_token_expired(self):
+        if self.token_expires is None:
+            return False
+        current_time = int(time.time())
+        return current_time >= self.token_expires
+
+    def _renew_token(self):
+        self.login(self.email, self.password)
+
+    def logout(self):
+        with self._request_lock:
+            if not self.access_token or not self.uid or not self.client:
+                raise ValueError("Not logged in")
+            url = f"{self.base_url}/auth/sign_out"
+            response = requests.delete(url, headers=self._auth_headers(), timeout=5)
+            response.raise_for_status()
+            return response.json()
 
     def get_user_info(self):
         return self._get_endpoint("/users/me")
@@ -120,19 +136,23 @@ class CowboyAPIClient:
         return self._get_endpoint("/theft")
 
     def _get_endpoint(self, endpoint, timeout=30):
-        if not self.access_token or not self.uid or not self.client:
-            raise ValueError("Not logged in")
-        if self._is_token_expired():
-            self._renew_token()
-        url = f"{self.base_url}{endpoint}"
-        headers = {
-            "content-type": "application/json",
-            "X-Cowboy-App-Token": self.app_token,
-            "Access-Token": self.access_token,
-            "Client-Type": self.client_type,
-            "Uid": self.uid,
-            "Client": self.client,
-        }
-        response = requests.get(url, headers=headers, timeout=timeout)
-        response.raise_for_status()
-        return response.json()
+        with self._request_lock:
+            if not self.access_token or not self.uid or not self.client:
+                raise ValueError("Not logged in")
+            if self._is_token_expired():
+                self._renew_token()
+
+            url = f"{self.base_url}{endpoint}"
+            response = requests.get(
+                url, headers=self._auth_headers(), timeout=timeout
+            )
+
+            if response.status_code == 401:
+                self._renew_token()
+                response = requests.get(
+                    url, headers=self._auth_headers(), timeout=timeout
+                )
+
+            response.raise_for_status()
+            self._update_session(response)
+            return response.json()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,235 @@
+"""Tests for the Cowboy API client."""
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+from unittest.mock import patch
+
+import pytest
+from requests import HTTPError, Response
+
+from custom_components.cowboy._client import CowboyAPIClient
+
+
+def _response(status_code=200, payload=None, headers=None):
+    """Build a real requests response for client tests."""
+    response = Response()
+    response.status_code = status_code
+    response.url = "https://app-api.cowboy.bike/test"
+    response._content = json.dumps(payload or {}).encode()
+    if headers:
+        response.headers.update(headers)
+    return response
+
+
+def _login_response(
+    token="initial-token", client="initial-client", expiry=9_999_999_999
+):
+    """Build a successful login response."""
+    return _response(
+        payload={"data": {"bike": {"id": 123}}},
+        headers={
+            "Access-Token": token,
+            "Uid": "test@example.com",
+            "Client": client,
+            "Expiry": str(expiry),
+        },
+    )
+
+
+def test_response_auth_headers_are_rotated():
+    """Successful responses should update credentials for the next request."""
+    rotated_headers = {
+        "Access-Token": "rotated-token",
+        "Uid": "rotated@example.com",
+        "Client": "rotated-client",
+        "Expiry": "9999999999",
+    }
+
+    with (
+        patch(
+            "custom_components.cowboy._client.requests.post",
+            return_value=_login_response(),
+        ),
+        patch(
+            "custom_components.cowboy._client.requests.get",
+            side_effect=[
+                _response(payload={"id": 123}, headers=rotated_headers),
+                _response(payload={"id": 123}),
+            ],
+        ) as mock_get,
+    ):
+        client = CowboyAPIClient()
+        client.login("test@example.com", "password")
+
+        client.get_bike()
+        client.get_bike()
+
+    first_headers = mock_get.call_args_list[0].kwargs["headers"]
+    second_headers = mock_get.call_args_list[1].kwargs["headers"]
+    assert first_headers["Access-Token"] == "initial-token"
+    assert second_headers["Access-Token"] == "rotated-token"
+    assert second_headers["Uid"] == "rotated@example.com"
+    assert second_headers["Client"] == "rotated-client"
+    assert client.token_expires == 9_999_999_999
+
+
+def test_expired_token_is_renewed_before_request():
+    """An expired session should be renewed before sending the request."""
+    with (
+        patch(
+            "custom_components.cowboy._client.requests.post",
+            side_effect=[
+                _login_response(expiry=100),
+                _login_response("renewed-token", "renewed-client", 300),
+            ],
+        ) as mock_post,
+        patch(
+            "custom_components.cowboy._client.requests.get",
+            return_value=_response(payload={"id": 123}),
+        ) as mock_get,
+        patch("custom_components.cowboy._client.time.time", return_value=100),
+    ):
+        client = CowboyAPIClient()
+        client.login("test@example.com", "password")
+
+        result = client.get_bike()
+
+    assert result == {"id": 123}
+    assert mock_post.call_count == 2
+    assert mock_get.call_count == 1
+    assert mock_get.call_args.kwargs["headers"]["Access-Token"] == "renewed-token"
+    assert mock_get.call_args.kwargs["headers"]["Client"] == "renewed-client"
+
+
+def test_unauthorized_request_reauthenticates_and_retries_once():
+    """A 401 should trigger one login and one retry with new credentials."""
+    with (
+        patch(
+            "custom_components.cowboy._client.requests.post",
+            side_effect=[
+                _login_response(),
+                _login_response("renewed-token", "renewed-client"),
+            ],
+        ) as mock_post,
+        patch(
+            "custom_components.cowboy._client.requests.get",
+            side_effect=[
+                _response(status_code=401),
+                _response(payload={"id": 123}),
+            ],
+        ) as mock_get,
+    ):
+        client = CowboyAPIClient()
+        client.login("test@example.com", "password")
+
+        result = client.get_bike()
+
+    assert result == {"id": 123}
+    assert mock_post.call_count == 2
+    assert mock_get.call_count == 2
+    assert mock_get.call_args_list[0].kwargs["headers"]["Access-Token"] == (
+        "initial-token"
+    )
+    assert mock_get.call_args_list[1].kwargs["headers"]["Access-Token"] == (
+        "renewed-token"
+    )
+
+
+def test_repeated_unauthorized_is_raised():
+    """A repeated 401 should be raised instead of starting a retry loop."""
+    repeated_unauthorized = _response(status_code=401)
+
+    with (
+        patch(
+            "custom_components.cowboy._client.requests.post",
+            side_effect=[_login_response(), _login_response("renewed-token")],
+        ) as mock_post,
+        patch(
+            "custom_components.cowboy._client.requests.get",
+            side_effect=[_response(status_code=401), repeated_unauthorized],
+        ) as mock_get,
+    ):
+        client = CowboyAPIClient()
+        client.login("test@example.com", "password")
+
+        with pytest.raises(HTTPError) as error:
+            client.get_bike()
+
+    assert error.value.response is repeated_unauthorized
+    assert mock_post.call_count == 2
+    assert mock_get.call_count == 2
+
+
+def test_non_authentication_error_is_not_retried():
+    """A non-401 response should be raised without reauthentication."""
+    server_error = _response(status_code=500)
+
+    with (
+        patch(
+            "custom_components.cowboy._client.requests.post",
+            return_value=_login_response(),
+        ) as mock_post,
+        patch(
+            "custom_components.cowboy._client.requests.get",
+            return_value=server_error,
+        ) as mock_get,
+    ):
+        client = CowboyAPIClient()
+        client.login("test@example.com", "password")
+
+        with pytest.raises(HTTPError) as error:
+            client.get_bike()
+
+    assert error.value.response is server_error
+    assert mock_post.call_count == 1
+    assert mock_get.call_count == 1
+
+
+def test_requests_are_serialized():
+    """Concurrent requests should not race while rotating credentials."""
+    first_request_started = Event()
+    release_first_request = Event()
+    second_request_started = Event()
+    request_headers = []
+
+    def get_response(url, headers, timeout):
+        """Block the first request while recording credentials in use."""
+        request_headers.append(headers)
+        if len(request_headers) == 1:
+            first_request_started.set()
+            assert release_first_request.wait(timeout=2)
+            return _response(
+                payload={"id": 123},
+                headers={"Access-Token": "rotated-token"},
+            )
+        second_request_started.set()
+        return _response(payload={"id": 123})
+
+    with (
+        patch(
+            "custom_components.cowboy._client.requests.post",
+            return_value=_login_response(),
+        ),
+        patch(
+            "custom_components.cowboy._client.requests.get",
+            side_effect=get_response,
+        ),
+        ThreadPoolExecutor(max_workers=2) as executor,
+    ):
+        client = CowboyAPIClient()
+        client.login("test@example.com", "password")
+        first_result = executor.submit(client.get_bike)
+        assert first_request_started.wait(timeout=2)
+        second_result = executor.submit(client.get_bike)
+
+        try:
+            assert not second_request_started.wait(timeout=0.1)
+        finally:
+            release_first_request.set()
+
+        assert first_result.result(timeout=2) == {"id": 123}
+        assert second_result.result(timeout=2) == {"id": 123}
+
+    assert request_headers[0]["Access-Token"] == "initial-token"
+    assert request_headers[1]["Access-Token"] == "rotated-token"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -58,6 +58,7 @@ def _configure_mock(mock_requests, bike_id=123, nickname="Test Bike"):
 
     get_response = mock_requests.get.return_value
     get_response.status_code = 200
+    get_response.headers = {}
     # GET /bikes/{id} returns the bike object directly (not wrapped in "data").
     get_response.json.return_value = bike_payload["data"]["bike"]
 


### PR DESCRIPTION
Cowboy can rotate authentication headers on API responses, but the integration only retained headers returned during sign-in. The independently scheduled coordinators also share one client, so simultaneous requests could race while session credentials changed.

This serializes access to the shared client, retains rotated credentials from successful responses, and reauthenticates and retries once after a 401. Repeated authentication failures and non-authentication errors continue to surface normally.

Testing:
- `ruff check .`
- `pytest tests/ -v --cov=custom_components.cowboy`