### PR TITLE
fix: keep bike tracker locations current

### DIFF
--- a/custom_components/cowboy/device_tracker.py
+++ b/custom_components/cowboy/device_tracker.py
@@ -1,5 +1,7 @@
 """Cowboy device tracker."""
 
+import math
+
 from homeassistant.components.device_tracker import SourceType, TrackerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -19,6 +21,28 @@ from .coordinator import CowboyBikeCoordinatedEntity, CowboyBikeUpdateCoordinato
 PARALLEL_UPDATES = 1
 
 
+def _coordinate(value, minimum, maximum) -> float | None:
+    """Return a valid numeric coordinate."""
+    try:
+        coordinate = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(coordinate) or not minimum <= coordinate <= maximum:
+        return None
+    return coordinate
+
+
+def _accuracy(value) -> float:
+    """Return a valid GPS accuracy in meters."""
+    try:
+        accuracy = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if not math.isfinite(accuracy) or accuracy < 0:
+        return 0.0
+    return accuracy
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -35,6 +59,7 @@ class CowboyTracker(CowboyBikeCoordinatedEntity, TrackerEntity):
     _attr_force_update = False
     _attr_icon = "mdi:bike"
     _attr_name = None
+    _attr_source_type = SourceType.GPS
 
     def __init__(
         self,
@@ -42,43 +67,41 @@ class CowboyTracker(CowboyBikeCoordinatedEntity, TrackerEntity):
     ) -> None:
         """Initialize the Tracker."""
         super().__init__(coordinator)
-        self._attr_extra_state_attributes = {}
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_tracker"
         self._attr_name = None
+        self._update_position()
 
-    @property
-    def latitude(self) -> float | None:
-        """Return latitude value of the device."""
-        return self._attr_extra_state_attributes.get(ATTR_LATITUDE, None)
+    def _update_position(self) -> None:
+        """Replace the current position with the latest coordinator snapshot."""
+        data = self.coordinator.data or {}
+        position = data.get("position") or {}
+        if not isinstance(position, dict):
+            position = {}
 
-    @property
-    def longitude(self) -> float | None:
-        """Return longitude value of the device."""
-        return self._attr_extra_state_attributes.get(ATTR_LONGITUDE, None)
+        latitude = _coordinate(position.get(ATTR_LATITUDE), -90, 90)
+        longitude = _coordinate(position.get(ATTR_LONGITUDE), -180, 180)
+        if latitude is None or longitude is None:
+            latitude = longitude = None
 
-    @property
-    def location_accuracy(self) -> int:
-        """Return the location accuracy of the device.
-
-        Value in meters.
-        """
-        return self._attr_extra_state_attributes.get(ATTR_ACCURACY, None)
-
-    @property
-    def source_type(self) -> SourceType:
-        """Return the source type, eg gps or router, of the device."""
-        return SourceType.GPS
+        accuracy = _accuracy(position.get(ATTR_ACCURACY))
+        self._attr_latitude = latitude
+        self._attr_longitude = longitude
+        self._attr_location_accuracy = accuracy
+        self._attr_extra_state_attributes = {
+            ATTR_ACCURACY: accuracy,
+            ATTR_LOC_NAME: position.get("address"),
+            ATTR_LOC_RECEIVED_AT: position.get("received_at"),
+        }
+        if latitude is not None and longitude is not None:
+            self._attr_extra_state_attributes.update(
+                {
+                    ATTR_LATITUDE: latitude,
+                    ATTR_LONGITUDE: longitude,
+                }
+            )
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._attr_extra_state_attributes.update(
-            {
-                ATTR_LATITUDE: self.coordinator.data["position"]["latitude"],
-                ATTR_LONGITUDE: self.coordinator.data["position"]["longitude"],
-                ATTR_ACCURACY: self.coordinator.data["position"]["accuracy"],
-                ATTR_LOC_NAME: self.coordinator.data["position"]["address"],
-                ATTR_LOC_RECEIVED_AT: self.coordinator.data["position"]["received_at"],
-            }
-        )
+        self._update_position()
         self.async_write_ha_state()

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1,0 +1,185 @@
+"""Tests for the Cowboy device tracker."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.components import zone
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from custom_components.cowboy.const import (
+    ATTR_ACCURACY,
+    ATTR_LATITUDE,
+    ATTR_LOC_NAME,
+    ATTR_LOC_RECEIVED_AT,
+    ATTR_LONGITUDE,
+)
+from custom_components.cowboy.device_tracker import CowboyTracker
+
+
+def _coordinator(position):
+    """Build a coordinator with a bike position."""
+    coordinator = MagicMock()
+    coordinator.config_entry.entry_id = "entry-1"
+    coordinator.device_info = {}
+    coordinator.data = {"position": position}
+    return coordinator
+
+
+def _position(**overrides):
+    """Build a complete Cowboy position payload."""
+    position = {
+        "latitude": "51.5074",
+        "longitude": "-0.1278",
+        "accuracy": "1.45",
+        "address": "London",
+        "received_at": "2026-08-29T20:00:00Z",
+    }
+    position.update(overrides)
+    return position
+
+
+def test_tracker_initializes_from_coordinator_data():
+    """The first coordinator refresh should seed the tracker immediately."""
+    tracker = CowboyTracker(_coordinator(_position()))
+
+    assert tracker.latitude == 51.5074
+    assert tracker.longitude == -0.1278
+    assert tracker.location_accuracy == 1.45
+    assert tracker.extra_state_attributes == {
+        ATTR_ACCURACY: 1.45,
+        ATTR_LATITUDE: 51.5074,
+        ATTR_LONGITUDE: -0.1278,
+        ATTR_LOC_NAME: "London",
+        ATTR_LOC_RECEIVED_AT: "2026-08-29T20:00:00Z",
+    }
+
+
+async def test_tracker_coordinates_support_home_zone_lookup(hass: HomeAssistant):
+    """Normalized coordinates should work with Home Assistant zone matching."""
+    assert await async_setup_component(hass, "zone", {})
+    tracker = CowboyTracker(
+        _coordinator(
+            _position(
+                latitude=str(hass.config.latitude),
+                longitude=str(hass.config.longitude),
+            )
+        )
+    )
+
+    active_zone = zone.async_active_zone(
+        hass, tracker.latitude, tracker.longitude, tracker.location_accuracy
+    )
+
+    assert active_zone is not None
+    assert active_zone.entity_id == zone.ENTITY_ID_HOME
+
+
+def test_tracker_replaces_position_on_coordinator_update():
+    """A new coordinator snapshot should replace every location field."""
+    coordinator = _coordinator(_position())
+    tracker = CowboyTracker(coordinator)
+    tracker.async_write_ha_state = MagicMock()
+    coordinator.data = {
+        "position": _position(
+            latitude=48.8566,
+            longitude=2.3522,
+            accuracy=2,
+            address="Paris",
+            received_at="2026-08-29T21:00:00Z",
+        )
+    }
+
+    tracker._handle_coordinator_update()
+
+    assert tracker.latitude == 48.8566
+    assert tracker.longitude == 2.3522
+    assert tracker.location_accuracy == 2.0
+    assert tracker.extra_state_attributes[ATTR_LOC_NAME] == "Paris"
+    assert tracker.extra_state_attributes[ATTR_LOC_RECEIVED_AT] == (
+        "2026-08-29T21:00:00Z"
+    )
+    tracker.async_write_ha_state.assert_called_once_with()
+
+
+def test_missing_optional_position_fields_do_not_block_update():
+    """Optional location metadata should not prevent fresh GPS coordinates."""
+    coordinator = _coordinator(_position())
+    tracker = CowboyTracker(coordinator)
+    tracker.async_write_ha_state = MagicMock()
+    coordinator.data = {
+        "position": {
+            "latitude": "48.8566",
+            "longitude": "2.3522",
+        }
+    }
+
+    tracker._handle_coordinator_update()
+
+    assert tracker.latitude == 48.8566
+    assert tracker.longitude == 2.3522
+    assert tracker.location_accuracy == 0.0
+    assert tracker.extra_state_attributes[ATTR_LOC_NAME] is None
+    assert tracker.extra_state_attributes[ATTR_LOC_RECEIVED_AT] is None
+
+
+@pytest.mark.parametrize(
+    "position",
+    [
+        None,
+        {},
+        {"latitude": 51.5074},
+        {"longitude": -0.1278},
+        "invalid",
+    ],
+)
+def test_incomplete_position_clears_stale_coordinates(position):
+    """An incomplete snapshot should not leave old coordinates displayed."""
+    coordinator = _coordinator(_position())
+    tracker = CowboyTracker(coordinator)
+    tracker.async_write_ha_state = MagicMock()
+    coordinator.data = {"position": position}
+
+    tracker._handle_coordinator_update()
+
+    assert tracker.latitude is None
+    assert tracker.longitude is None
+    assert tracker.location_accuracy == 0.0
+    assert ATTR_LATITUDE not in tracker.extra_state_attributes
+    assert ATTR_LONGITUDE not in tracker.extra_state_attributes
+    tracker.async_write_ha_state.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    ("latitude", "longitude"),
+    [
+        ("invalid", -0.1278),
+        (51.5074, "invalid"),
+        (float("nan"), -0.1278),
+        (51.5074, float("inf")),
+        (91, -0.1278),
+        (51.5074, -181),
+    ],
+)
+def test_invalid_coordinates_are_cleared(latitude, longitude):
+    """Invalid Cowboy coordinates should produce an unknown location."""
+    tracker = CowboyTracker(
+        _coordinator(_position(latitude=latitude, longitude=longitude))
+    )
+
+    assert tracker.latitude is None
+    assert tracker.longitude is None
+    assert ATTR_LATITUDE not in tracker.extra_state_attributes
+    assert ATTR_LONGITUDE not in tracker.extra_state_attributes
+
+
+@pytest.mark.parametrize("accuracy", [None, "invalid", -1, float("nan")])
+def test_invalid_accuracy_uses_safe_default(accuracy):
+    """Invalid GPS accuracy should not discard otherwise valid coordinates."""
+    tracker = CowboyTracker(_coordinator(_position(accuracy=accuracy)))
+
+    assert tracker.latitude == 51.5074
+    assert tracker.longitude == -0.1278
+    assert tracker.location_accuracy == 0.0
+    assert tracker.extra_state_attributes[ATTR_ACCURACY] == 0.0


### PR DESCRIPTION
Cowboy GPS values can arrive as numeric strings, and position payloads may omit optional fields or the position entirely. The tracker currently waits for a second coordinator refresh before publishing its initial location, then indexes every position field before writing state; any incomplete response leaves the previous coordinates and home/away state displayed indefinitely.

This initializes the tracker from the completed first refresh, normalizes and validates coordinates for Home Assistant zone matching, handles optional metadata independently, and clears obsolete coordinates when Cowboy no longer supplies a valid pair. Existing custom location attributes are retained for compatibility.

This does not change the pinned `/bikes/{id}` endpoint or imply continuous GPS updates; `location_received_at` remains the timestamp of Cowboy’s latest bike report.

Testing:
- `ruff check .`
- `pytest tests/ -v --cov=custom_components.cowboy`