### PR TITLE
fix: recover from Cowboy API failures

### DIFF
--- a/custom_components/cowboy/__init__.py
+++ b/custom_components/cowboy/__init__.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 
-from homeassistant.config_entries import ConfigEntry
+from requests import HTTPError, RequestException
+
+from homeassistant.config_entries import ConfigEntry, ConfigEntryNotReady
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 
@@ -42,13 +45,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up cowboy from a config entry."""
     bike_id = entry.data[CONF_BIKE_ID]
     cowboy_api = CowboyAPIClient(bike_id=bike_id)
-    await hass.async_add_executor_job(
-        cowboy_api.login, entry.data["username"], entry.data["password"]
-    )
+    try:
+        await hass.async_add_executor_job(
+            cowboy_api.login, entry.data["username"], entry.data["password"]
+        )
 
-    # Fetch the pinned bike explicitly — the active bike in the login response
-    # may not be the one this entry tracks.
-    bike = await hass.async_add_executor_job(cowboy_api.get_bike)
+        # Fetch the pinned bike explicitly — the active bike in the login response
+        # may not be the one this entry tracks.
+        bike = await hass.async_add_executor_job(cowboy_api.get_bike)
+    except HTTPError as err:
+        response = err.response
+        if response is not None and response.status_code == 401:
+            raise ConfigEntryAuthFailed("Invalid Cowboy authentication") from err
+        raise ConfigEntryNotReady(
+            f"Error communicating with Cowboy API: {err}"
+        ) from err
+    except (RequestException, TimeoutError, TypeError, ValueError) as err:
+        raise ConfigEntryNotReady(
+            f"Error communicating with Cowboy API: {err}"
+        ) from err
+
+    if (
+        not isinstance(bike, dict)
+        or not isinstance(bike.get("model"), dict)
+        or not bike["model"].get("name")
+    ):
+        raise ConfigEntryNotReady("Unexpected response from Cowboy API")
 
     # Device identifier is keyed on bike_id so the registry entry survives
     # config-entry recreation and stays stable across reloads.
@@ -62,22 +84,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     scan_interval = entry.options.get(CONF_SCAN_INTERVAL, 1)
     bike_coordinator = CowboyBikeUpdateCoordinator(
-        hass, device, cowboy_api, update_interval=timedelta(minutes=scan_interval)
+        hass,
+        device,
+        cowboy_api,
+        entry,
+        update_interval=timedelta(minutes=scan_interval),
     )
     release_coordinator = CowboyReleaseUpdateCoordinator(
-        hass, device, cowboy_api, update_interval=timedelta(hours=1)
+        hass, device, cowboy_api, entry, update_interval=timedelta(hours=1)
     )
     trips_coordinator = CowboyTripsUpdateCoordinator(
-        hass, device, cowboy_api, update_interval=timedelta(minutes=15)
+        hass, device, cowboy_api, entry, update_interval=timedelta(minutes=15)
     )
 
     await bike_coordinator.async_config_entry_first_refresh()
-    await release_coordinator.async_config_entry_first_refresh()
-    try:
-        await trips_coordinator.async_config_entry_first_refresh()
-    except Exception as err:  # noqa: BLE001
-        # Trips are secondary; a failure here shouldn't block entry setup.
-        _LOGGER.warning("Initial trips refresh failed, continuing: %s", err)
+    for coordinator_name, coordinator in (
+        ("release", release_coordinator),
+        ("trips", trips_coordinator),
+    ):
+        try:
+            await coordinator.async_config_entry_first_refresh()
+        except ConfigEntryNotReady as err:
+            # Secondary endpoints shouldn't block the core bike entities.
+            _LOGGER.warning(
+                "Initial %s refresh failed, continuing: %s", coordinator_name, err
+            )
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
@@ -86,8 +117,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         CONF_RELEASE_COORDINATOR: release_coordinator,
         CONF_TRIPS_COORDINATOR: trips_coordinator,
     }
-
-    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -154,11 +183,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             pass
 
     return True
-
-
-async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload the entry when options change."""
-    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/cowboy/config_flow.py
+++ b/custom_components/cowboy/config_flow.py
@@ -33,18 +33,23 @@ class CowboyHub:
     name = None
     bike_id = None
 
-    def __init__(self) -> None:
+    def __init__(self, bike_id: int | None = None) -> None:
         """Initialize."""
         self.auth = None
+        self.bike_id = bike_id
 
     def authenticate(self, username: str, password: str) -> bool:
         """Test if we can authenticate with the host."""
         try:
-            self.cowboy_api = CowboyAPIClient()
+            self.cowboy_api = CowboyAPIClient(bike_id=self.bike_id)
             resp = self.cowboy_api.login(username, password)
-            bike = resp["data"]["bike"]
+            bike = (
+                self.cowboy_api.get_bike()
+                if self.bike_id is not None
+                else resp["data"]["bike"]
+            )
             self.bike_id = bike["id"]
-            self.name = bike["nickname"] or bike["model"]["name"]
+            self.name = bike.get("nickname") or bike["model"]["name"]
         except HTTPError as http_err:
             response = http_err.response
             if response is not None and response.status_code == 401:
@@ -57,12 +62,14 @@ class CowboyHub:
         return True
 
 
-async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+async def validate_input(
+    hass: HomeAssistant, data: dict[str, Any], bike_id: int | None = None
+) -> dict[str, Any]:
     """Validate the user input allows us to connect.
 
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
-    hub = CowboyHub()
+    hub = CowboyHub(bike_id)
 
     result = await hass.async_add_executor_job(
         hub.authenticate, data[CONF_USERNAME], data[CONF_PASSWORD]
@@ -83,6 +90,47 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for cowboy."""
 
     VERSION = 2
+
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> FlowResult:
+        """Handle configuration by an expired authentication token."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm updated Cowboy credentials."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                await validate_input(
+                    self.hass,
+                    user_input,
+                    self._reauth_entry.data[CONF_BIKE_ID],
+                )
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    self._reauth_entry,
+                    data_updates={
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -125,7 +173,9 @@ class CowboyOptionsFlow(config_entries.OptionsFlow):
     ) -> FlowResult:
         """Manage the options."""
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            result = self.async_create_entry(title="", data=user_input)
+            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
+            return result
 
         current = self.config_entry.options.get(CONF_SCAN_INTERVAL, 1)
         schema = vol.Schema(

--- a/custom_components/cowboy/coordinator.py
+++ b/custom_components/cowboy/coordinator.py
@@ -3,11 +3,13 @@
 import asyncio
 from datetime import timedelta
 import logging
+from typing import NoReturn
 
-from requests import HTTPError
+from requests import HTTPError, RequestException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -21,6 +23,20 @@ from .const import ATTRIBUTION, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
+def _raise_update_error(err: RequestException | TimeoutError) -> NoReturn:
+    """Translate Cowboy API errors to Home Assistant coordinator errors."""
+    if isinstance(err, HTTPError):
+        response = err.response
+        if response is not None and response.status_code == 401:
+            raise ConfigEntryAuthFailed("Invalid Cowboy authentication") from err
+    raise UpdateFailed(f"Error communicating with Cowboy API: {err}") from err
+
+
+def _raise_invalid_response() -> NoReturn:
+    """Raise a coordinator error for an unexpected Cowboy response."""
+    raise UpdateFailed("Unexpected response from Cowboy API")
+
+
 class CowboyUpdateCoordinator(DataUpdateCoordinator):
     """Abstract Cowboy coordinator to fetch data from the inofficial API at a set interval."""
 
@@ -32,10 +48,17 @@ class CowboyUpdateCoordinator(DataUpdateCoordinator):
         hass: HomeAssistant,
         device: DeviceInfo,
         cowboy_api: CowboyAPIClient,
+        config_entry: ConfigEntry,
         update_interval=timedelta(minutes=1),
     ) -> None:
         """Initialize the coordinator with the given API client."""
-        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=update_interval)
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=DOMAIN,
+            update_interval=update_interval,
+        )
         _LOGGER.info("Initializing CowboyCoordinator")
         self.cowboy_api = cowboy_api
         self.device_info = device
@@ -49,17 +72,15 @@ class CowboyBikeUpdateCoordinator(CowboyUpdateCoordinator):
         try:
             async with asyncio.timeout(30):
                 bike = await self.hass.async_add_executor_job(self.cowboy_api.get_bike)
+                if not isinstance(bike, dict):
+                    _raise_invalid_response()
                 # can change over time, so we need to update it
                 self.device_info["sw_version"] = bike.get("firmware_version")
                 self.device_info["name"] = bike.get("nickname")
                 _LOGGER.debug("bike data fetched: %s", bike)
                 return bike
-        except HTTPError as http_err:
-            if http_err.response.status_code == 401:
-                raise UpdateFailed("Unable to fetch data from Cowboy API") from http_err
-            raise UpdateFailed(
-                f"Error communicating with API: {http_err}"
-            ) from http_err
+        except (RequestException, TimeoutError) as err:
+            _raise_update_error(err)
 
 
 class CowboyReleaseUpdateCoordinator(CowboyUpdateCoordinator):
@@ -72,14 +93,17 @@ class CowboyReleaseUpdateCoordinator(CowboyUpdateCoordinator):
                 releases = await self.hass.async_add_executor_job(
                     self.cowboy_api.get_releases
                 )
+                if releases is None:
+                    releases = {}
+                if not isinstance(releases, dict):
+                    _raise_invalid_response()
+                firmware = releases.get("firmware")
+                if firmware is not None and not isinstance(firmware, dict):
+                    _raise_invalid_response()
                 _LOGGER.debug("release data fetched: %s", releases)
                 return releases
-        except HTTPError as http_err:
-            if http_err.response.status_code == 401:
-                raise UpdateFailed("Unable to fetch data from Cowboy API") from http_err
-            raise UpdateFailed(
-                f"Error communicating with API: {http_err}"
-            ) from http_err
+        except (RequestException, TimeoutError) as err:
+            _raise_update_error(err)
 
 
 class CowboyTripsUpdateCoordinator(CowboyUpdateCoordinator):
@@ -99,13 +123,28 @@ class CowboyTripsUpdateCoordinator(CowboyUpdateCoordinator):
                     "trip data fetched: recent=%s highlights=%s", recent, highlights
                 )
 
-                trips = (recent or {}).get("trips") or []
+                if recent is None:
+                    recent = {}
+                if highlights is None:
+                    highlights = []
+                if not isinstance(recent, dict) or not isinstance(highlights, list):
+                    _raise_invalid_response()
+
+                trips = recent.get("trips") or []
+                if not isinstance(trips, list):
+                    _raise_invalid_response()
                 last_trip = trips[0] if trips else None
+                if trips and not isinstance(last_trip, dict):
+                    _raise_invalid_response()
 
                 today_distance = None
-                for entry in highlights or []:
+                for entry in highlights:
+                    if not isinstance(entry, dict):
+                        _raise_invalid_response()
                     if entry.get("type") == "today_highlight":
                         payload = entry.get("payload") or {}
+                        if not isinstance(payload, dict):
+                            _raise_invalid_response()
                         today_distance = payload.get("distance")
                         break
 
@@ -113,12 +152,8 @@ class CowboyTripsUpdateCoordinator(CowboyUpdateCoordinator):
                     "last_trip": last_trip,
                     "today_distance": today_distance,
                 }
-        except HTTPError as http_err:
-            if http_err.response.status_code == 401:
-                raise UpdateFailed("Unable to fetch data from Cowboy API") from http_err
-            raise UpdateFailed(
-                f"Error communicating with API: {http_err}"
-            ) from http_err
+        except (RequestException, TimeoutError) as err:
+            _raise_update_error(err)
 
 
 class CowboyBikeCoordinatedEntity(CoordinatorEntity[CowboyBikeUpdateCoordinator]):

--- a/custom_components/cowboy/strings.json
+++ b/custom_components/cowboy/strings.json
@@ -6,6 +6,12 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
         }
+      },
+      "reauth_confirm": {
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
       }
     },
     "error": {
@@ -14,7 +20,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "options": {

--- a/custom_components/cowboy/translations/en.json
+++ b/custom_components/cowboy/translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "reauth_successful": "Re-authentication was successful"
         },
         "error": {
             "cannot_connect": "Failed to connect",
@@ -10,6 +11,12 @@
         },
         "step": {
             "user": {
+                "data": {
+                    "password": "Password",
+                    "username": "Username"
+                }
+            },
+            "reauth_confirm": {
                 "data": {
                     "password": "Password",
                     "username": "Username"

--- a/custom_components/cowboy/translations/pt.json
+++ b/custom_components/cowboy/translations/pt.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "O dispositivo já está configurado"
+            "already_configured": "O dispositivo já está configurado",
+            "reauth_successful": "A reautenticação foi bem-sucedida"
         },
         "error": {
             "cannot_connect": "Falha ao conectar",
@@ -10,6 +11,12 @@
         },
         "step": {
             "user": {
+                "data": {
+                    "password": "Palavra-passe",
+                    "username": "Nome de utilizador"
+                }
+            },
+            "reauth_confirm": {
                 "data": {
                     "password": "Palavra-passe",
                     "username": "Nome de utilizador"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,141 @@
+"""Tests for Cowboy data update coordinators."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from requests import ConnectionError, HTTPError, Response, Timeout
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from custom_components.cowboy._client import CowboyAPIClient
+from custom_components.cowboy.const import CONF_BIKE_ID, DOMAIN
+from custom_components.cowboy.coordinator import (
+    CowboyBikeUpdateCoordinator,
+    CowboyReleaseUpdateCoordinator,
+    CowboyTripsUpdateCoordinator,
+)
+
+
+def _config_entry() -> config_entries.ConfigEntry:
+    """Create a Cowboy config entry."""
+    return config_entries.ConfigEntry(
+        version=2,
+        minor_version=1,
+        domain=DOMAIN,
+        title="Test",
+        data={
+            CONF_USERNAME: "test@example.com",
+            CONF_PASSWORD: "test_password",
+            CONF_BIKE_ID: 123,
+        },
+        source="test",
+        options={},
+        unique_id="123",
+        discovery_keys=set(),
+    )
+
+
+def _coordinator(hass, coordinator_class):
+    """Create a coordinator with successful API defaults."""
+    api = MagicMock(spec=CowboyAPIClient)
+    api.get_bike.return_value = {"nickname": "Test", "firmware_version": "1.0"}
+    api.get_releases.return_value = {}
+    api.get_trips_recent.return_value = {"trips": []}
+    api.get_trips_highlights.return_value = []
+    device = DeviceInfo(identifiers={(DOMAIN, "123")})
+    return coordinator_class(hass, device, api, _config_entry()), api
+
+
+def _http_error(status: int) -> HTTPError:
+    """Create an HTTP error with a real requests response."""
+    response = Response()
+    response.status_code = status
+    return HTTPError(f"{status} response", response=response)
+
+
+@pytest.mark.parametrize(
+    ("coordinator_class", "method"),
+    [
+        (CowboyBikeUpdateCoordinator, "get_bike"),
+        (CowboyReleaseUpdateCoordinator, "get_releases"),
+        (CowboyTripsUpdateCoordinator, "get_trips_recent"),
+    ],
+)
+async def test_auth_errors_request_reauthentication(
+    hass, coordinator_class, method
+):
+    """Authentication failures should start Home Assistant reauthentication."""
+    coordinator, api = _coordinator(hass, coordinator_class)
+    error = _http_error(401)
+    getattr(api, method).side_effect = error
+
+    with pytest.raises(ConfigEntryAuthFailed) as err:
+        await coordinator._async_update_data()
+
+    assert err.value.__cause__ is error
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ConnectionError("offline"),
+        Timeout("timed out"),
+        TimeoutError("timed out"),
+        _http_error(500),
+        HTTPError("missing response"),
+    ],
+)
+async def test_api_errors_are_update_failures(hass, error):
+    """Transient API errors should mark coordinator data unavailable."""
+    coordinator, api = _coordinator(hass, CowboyBikeUpdateCoordinator)
+    api.get_bike.side_effect = error
+
+    with pytest.raises(UpdateFailed) as err:
+        await coordinator._async_update_data()
+
+    assert err.value.__cause__ is error
+
+
+@pytest.mark.parametrize(
+    ("coordinator_class", "method", "payload"),
+    [
+        (CowboyBikeUpdateCoordinator, "get_bike", None),
+        (CowboyReleaseUpdateCoordinator, "get_releases", []),
+        (
+            CowboyReleaseUpdateCoordinator,
+            "get_releases",
+            {"firmware": "invalid"},
+        ),
+        (CowboyTripsUpdateCoordinator, "get_trips_recent", []),
+        (
+            CowboyTripsUpdateCoordinator,
+            "get_trips_recent",
+            {"trips": [None]},
+        ),
+        (CowboyTripsUpdateCoordinator, "get_trips_highlights", [None]),
+    ],
+)
+async def test_malformed_responses_are_update_failures(
+    hass, coordinator_class, method, payload
+):
+    """Malformed cloud responses should not escape as unexpected exceptions."""
+    coordinator, api = _coordinator(hass, coordinator_class)
+    getattr(api, method).return_value = payload
+
+    with pytest.raises(UpdateFailed, match="Unexpected response"):
+        await coordinator._async_update_data()
+
+
+async def test_successful_bike_update_refreshes_device_info(hass):
+    """A successful update should return data and update device metadata."""
+    coordinator, api = _coordinator(hass, CowboyBikeUpdateCoordinator)
+
+    data = await coordinator._async_update_data()
+
+    assert data is api.get_bike.return_value
+    assert coordinator.device_info["name"] == "Test"
+    assert coordinator.device_info["sw_version"] == "1.0"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,8 @@
 """Tests for cowboy integration."""
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 import pytest
+from requests import ConnectionError, HTTPError, Response
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
@@ -30,6 +31,28 @@ MOCK_BIKE_RESPONSE = {
         }
     }
 }
+
+
+def _entry() -> config_entries.ConfigEntry:
+    """Create a Cowboy config entry."""
+    return config_entries.ConfigEntry(
+        version=2,
+        minor_version=1,
+        domain=DOMAIN,
+        title="Test",
+        data=MOCK_CONFIG,
+        source="test",
+        options={},
+        unique_id="123",
+        discovery_keys=set(),
+    )
+
+
+def _http_error(status: int) -> HTTPError:
+    """Create an HTTP error with a real requests response."""
+    response = Response()
+    response.status_code = status
+    return HTTPError(f"{status} response", response=response)
 
 
 def _configure_mock(mock_requests, bike_id=123, nickname="Test Bike"):
@@ -109,33 +132,65 @@ async def test_setup_unload_and_reload_entry(hass: HomeAssistant):
 
 async def test_setup_entry_fails_on_auth_error(hass: HomeAssistant):
     """Test setup with authentication failure."""
-    with patch('custom_components.cowboy._client.requests') as mock_requests:
-        mock_requests.post.side_effect = Exception("Auth failed")
+    entry = _entry()
+    hass.config_entries._entries[entry.entry_id] = entry
 
-        entry = config_entries.ConfigEntry(
-            version=2,
-            minor_version=1,
-            domain=DOMAIN,
-            title="Test",
-            data=MOCK_CONFIG,
-            source="test",
-            options={},
-            unique_id="123",
-            discovery_keys=set(),
-        )
-
-        hass.config_entries._entries[entry.entry_id] = entry
-
+    client = MagicMock()
+    client.login.side_effect = _http_error(401)
+    with patch("custom_components.cowboy.CowboyAPIClient", return_value=client):
         assert not await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        device_registry = dr.async_get(hass)
-        devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
-        for device in devices:
-            device_registry.async_remove_device(device.id)
+    assert entry.state is config_entries.ConfigEntryState.SETUP_ERROR
+    assert DOMAIN not in hass.data
 
-        hass.config_entries._entries.pop(entry.entry_id)
-        assert DOMAIN not in hass.data
+
+async def test_setup_entry_retries_connection_errors(hass: HomeAssistant):
+    """Test setup retries transient API failures."""
+    entry = _entry()
+    hass.config_entries._entries[entry.entry_id] = entry
+
+    client = MagicMock()
+    client.login.side_effect = ConnectionError("offline")
+    with patch("custom_components.cowboy.CowboyAPIClient", return_value=client):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
+    assert DOMAIN not in hass.data
+
+
+async def test_setup_entry_retries_malformed_bike_response(hass: HomeAssistant):
+    """Test setup retries when the API returns incomplete bike data."""
+    entry = _entry()
+    hass.config_entries._entries[entry.entry_id] = entry
+
+    client = MagicMock()
+    client.get_bike.return_value = {"nickname": "Test"}
+    with patch("custom_components.cowboy.CowboyAPIClient", return_value=client):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
+    assert DOMAIN not in hass.data
+
+
+async def test_setup_entry_ignores_secondary_endpoint_failure(hass: HomeAssistant):
+    """Test a release API outage does not block core bike entities."""
+    entry = _entry()
+    hass.config_entries._entries[entry.entry_id] = entry
+
+    client = MagicMock()
+    client.get_bike.return_value = MOCK_BIKE_RESPONSE["data"]["bike"]
+    client.get_releases.side_effect = ConnectionError("offline")
+    client.get_trips_recent.return_value = {"trips": []}
+    client.get_trips_highlights.return_value = []
+    with patch("custom_components.cowboy.CowboyAPIClient", return_value=client):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert entry.state is config_entries.ConfigEntryState.LOADED
+        assert await hass.config_entries.async_unload(entry.entry_id)
 
 async def test_scan_interval_option_applied(hass: HomeAssistant):
     """scan_interval from entry options is wired into the bike coordinator."""
@@ -172,6 +227,22 @@ async def test_scan_interval_option_applied(hass: HomeAssistant):
             device_registry.async_remove_device(device.id)
 
         hass.config_entries._entries.pop(entry.entry_id)
+
+
+async def test_options_flow_schedules_reload(hass: HomeAssistant):
+    """Changing the polling interval should reload the config entry once."""
+    entry = _entry()
+    hass.config_entries._entries[entry.entry_id] = entry
+
+    with patch.object(hass.config_entries, "async_schedule_reload") as reload_entry:
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {CONF_SCAN_INTERVAL: 5}
+        )
+
+    assert result["type"] == "create_entry"
+    assert entry.options[CONF_SCAN_INTERVAL] == 5
+    reload_entry.assert_called_once_with(entry.entry_id)
 
 
 
@@ -216,6 +287,74 @@ async def test_config_flow_validation(hass: HomeAssistant):
 
         for entry in hass.config_entries._entries.copy():
             await hass.config_entries.async_remove(entry)
+
+
+async def test_reauthentication_updates_credentials(hass: HomeAssistant):
+    """Test successful reauthentication updates the existing entry."""
+    entry = _entry()
+    hass.config_entries._entries[entry.entry_id] = entry
+
+    with patch("custom_components.cowboy._client.requests") as mock_requests:
+        _configure_mock(mock_requests)
+        login_payload = MOCK_BIKE_RESPONSE | {
+            "data": {
+                "bike": MOCK_BIKE_RESPONSE["data"]["bike"] | {"id": 456}
+            }
+        }
+        mock_requests.post.return_value.json.return_value = login_payload
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_REAUTH,
+                "entry_id": entry.entry_id,
+            },
+            data=entry.data,
+        )
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "reauth_confirm"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_USERNAME: "new@example.com",
+                CONF_PASSWORD: "new_password",
+            },
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_USERNAME] == "new@example.com"
+    assert entry.data[CONF_PASSWORD] == "new_password"
+    assert entry.data[CONF_BIKE_ID] == 123
+    assert mock_requests.get.call_args.args[0].endswith("/bikes/123")
+
+
+async def test_reauthentication_rejects_invalid_credentials(hass: HomeAssistant):
+    """Test invalid updated credentials keep the reauthentication form open."""
+    entry = _entry()
+    hass.config_entries._entries[entry.entry_id] = entry
+
+    with patch("custom_components.cowboy._client.requests") as mock_requests:
+        mock_requests.post.return_value.raise_for_status.side_effect = _http_error(401)
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_REAUTH,
+                "entry_id": entry.entry_id,
+            },
+            data=entry.data,
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_USERNAME: "test@example.com",
+                CONF_PASSWORD: "wrong_password",
+            },
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "invalid_auth"}
 
 
 async def test_config_flow_aborts_on_duplicate_bike(hass: HomeAssistant):


### PR DESCRIPTION
Cowboy API timeouts, connection failures, and malformed responses currently escape through inconsistent exception paths. During setup this leaves Home Assistant without retry semantics, while polling failures are logged as unexpected exceptions; expired credentials are treated as ordinary update failures with no way to repair them in the UI.

This maps transient setup failures to `ConfigEntryNotReady`, polling failures to `UpdateFailed`, and 401 responses to `ConfigEntryAuthFailed`. It adds a pinned-bike-aware reauthentication flow, validates the response shapes consumed by entities, and lets optional release/trips endpoint outages degrade independently instead of blocking core bike entities. Coordinators are linked to their config entry so runtime authentication failures start the correct reauthentication flow.

Testing:
- `ruff check .`
- `pytest tests/ -v --cov=custom_components.cowboy`