### PR TITLE
fix: keep bike sensor states current

### DIFF
--- a/custom_components/cowboy/binary_sensor.py
+++ b/custom_components/cowboy/binary_sensor.py
@@ -84,26 +84,33 @@ class CowboyBinarySensor(CowboyBikeCoordinatedEntity, BinarySensorEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
+        self._update_state()
+
+    def _update_state(self) -> None:
+        """Update state from the latest coordinator snapshot."""
+        coordinator_data = self.coordinator.data
+        data = coordinator_data if isinstance(coordinator_data, dict) else {}
+        self._attr_is_on = data.get(self.entity_description.key)
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._attr_is_on = self.coordinator.data[self.entity_description.key]
+        self._update_state()
         self.async_write_ha_state()
 
 
 class CowboyUpdateBinarySensor(CowboyBinarySensor):
     """Availability of an update for a Cowboy bike."""
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator.
+    def _update_state(self) -> None:
+        """Update firmware availability from the latest coordinator snapshot.
 
         This sensor is on if there is a firmware update available and
         the bike firmware is not the latest release. The firmware update
         must not have status: testing.
         """
-        data = self.coordinator.data or {}
+        coordinator_data = self.coordinator.data
+        data = coordinator_data if isinstance(coordinator_data, dict) else {}
         # The API returns `null` (not just missing) for some keys in
         # /releases (e.g. cockpit, wireless_charger). `firmware` itself
         # has been observed null too, and `dict.get(k, default)` only
@@ -119,5 +126,3 @@ class CowboyUpdateBinarySensor(CowboyBinarySensor):
         self._attr_is_on = (
             firmware_name != sw_version and firmware_status != "testing"
         )
-
-        self.async_write_ha_state()

--- a/custom_components/cowboy/sensor.py
+++ b/custom_components/cowboy/sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
+from math import isfinite
 from typing import Any
 
 from homeassistant.components.sensor import (
@@ -50,14 +51,71 @@ RIDE_MODE_OPTIONS = [
 ]
 
 
-def _parse_iso(value: str | None) -> datetime | None:
+def _parse_iso(value: Any) -> datetime | None:
     """ISO 8601 string → datetime, tolerant of missing/malformed values."""
-    if not value:
+    if not isinstance(value, str) or not value:
         return None
     try:
         return datetime.fromisoformat(value)
     except ValueError:
         return None
+
+
+def _as_float(value: Any) -> float | None:
+    """Return a finite number from Cowboy data, if possible."""
+    if isinstance(value, bool):
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if isfinite(result) else None
+
+
+def _matching_full_battery_range(data: dict[str, Any]) -> float | None:
+    """Return the full range for the bike's last ride mode."""
+    ride_mode = data.get("last_ride_mode")
+    autonomies = data.get("autonomies")
+    if ride_mode is None or not isinstance(autonomies, list):
+        return None
+    for autonomy in autonomies:
+        if not isinstance(autonomy, dict):
+            continue
+        if autonomy.get("ride_mode") == ride_mode:
+            full_range = _as_float(autonomy.get("full_battery_range"))
+            if full_range is not None:
+                return full_range
+    return None
+
+
+def _remaining_range(data: dict[str, Any]) -> float | None:
+    """Calculate remaining range without assuming optional fields are present."""
+    charge = _as_float(data.get("battery_state_of_charge"))
+    full_range = _matching_full_battery_range(data)
+    if full_range is None:
+        full_range = _as_float(data.get("autonomy"))
+    if charge is None or full_range is None:
+        return None
+    return charge / 100 * full_range
+
+
+def _battery_health(data: dict[str, Any]) -> float | None:
+    """Calculate battery health when the API supplies a usable full range."""
+    current_range = _as_float(data.get("autonomy"))
+    full_range = _matching_full_battery_range(data)
+    if current_range is None or full_range is None or full_range <= 0:
+        return None
+    return current_range / full_range * 100
+
+
+def _nested_value(data: dict[str, Any], *keys: str) -> Any:
+    """Read a value from nested dictionaries, tolerating partial data."""
+    value: Any = data
+    for key in keys:
+        if not isinstance(value, dict):
+            return None
+        value = value.get(key)
+    return value
 
 
 @dataclass
@@ -114,12 +172,7 @@ SENSOR_TYPES: tuple[CowboySensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DISTANCE,
         suggested_display_precision=0,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data['battery_state_of_charge'] / 100 * (
-            next(
-                (autonomy['full_battery_range'] for autonomy in data.get('autonomies', []) if autonomy['ride_mode'] == data.get('last_ride_mode')),
-                data.get('autonomy', 0)
-            )
-        ),
+        value_fn=_remaining_range,
     ),
     CowboySensorEntityDescription(
         key="battery_health",
@@ -128,10 +181,7 @@ SENSOR_TYPES: tuple[CowboySensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
         icon="mdi:battery-heart",
-        value_fn=lambda data: data['autonomy'] / next(
-            (autonomy['full_battery_range'] for autonomy in data['autonomies'] if autonomy['ride_mode'] == data['last_ride_mode']),
-            None
-        ) * 100
+        value_fn=_battery_health,
     ),
     CowboySensorEntityDescription(
         key="seen_at",
@@ -170,7 +220,7 @@ SENSOR_TYPES: tuple[CowboySensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTime.MINUTES,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:lock-clock",
-        value_fn=lambda data: (data.get("pending_settings") or {}).get("auto_lock"),
+        value_fn=lambda data: _nested_value(data, "pending_settings", "auto_lock"),
     ),
     CowboySensorEntityDescription(
         key="displayed_speed",
@@ -179,9 +229,9 @@ SENSOR_TYPES: tuple[CowboySensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:speedometer",
-        value_fn=lambda data: (
-            ((data.get("sku") or {}).get("features") or {}).get("displayed_speeds") or {}
-        ).get("default"),
+        value_fn=lambda data: _nested_value(
+            data, "sku", "features", "displayed_speeds", "default"
+        ),
     ),
 )
 
@@ -292,19 +342,22 @@ class CowboySensor(CowboyBikeCoordinatedEntity, SensorEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
+        self._update_state()
+
+    def _update_state(self) -> None:
+        """Update state from the latest coordinator snapshot."""
+        coordinator_data = self.coordinator.data
+        data = coordinator_data if isinstance(coordinator_data, dict) else {}
+        if not self.entity_description.value_fn:
+            self._attr_native_value = data.get(self.entity_description.key)
+        else:
+            self._attr_native_value = self.entity_description.value_fn(data)
+        self._attr_extra_state_attributes = self.entity_description.attrs(data)
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        if not self.entity_description.value_fn:
-            self._attr_native_value = self.coordinator.data[self.entity_description.key]
-        else:
-            self._attr_native_value = self.entity_description.value_fn(
-                self.coordinator.data
-            )
-        self._attr_extra_state_attributes = self.entity_description.attrs(
-            self.coordinator.data
-        )
+        self._update_state()
         self.async_write_ha_state()
 
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,72 @@
+"""Tests for Cowboy binary sensors."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+
+from custom_components.cowboy.binary_sensor import (
+    SENSOR_TYPES,
+    CowboyBinarySensor,
+    CowboyUpdateBinarySensor,
+)
+from custom_components.cowboy.sensor import CowboySensorEntityDescription
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("stolen", False),
+        ("crashed", True),
+        ("battery_inserted", False),
+    ],
+)
+def test_binary_sensor_uses_initial_data_and_clears_missing_values(key, value):
+    """Binary sensors should use the first refresh and not retain stale data."""
+    description = next(desc for desc in SENSOR_TYPES if desc.key == key)
+    coordinator = MagicMock()
+    coordinator.data = {key: value}
+    coordinator.config_entry.entry_id = "entry-1"
+    coordinator.device_info = {}
+
+    entity = CowboyBinarySensor(coordinator, description)
+    assert entity.is_on is value
+
+    coordinator.data = {}
+    entity._update_state()
+    assert entity.is_on is None
+
+
+@pytest.mark.parametrize("data", [[1], "invalid"])
+def test_binary_sensor_tolerates_malformed_coordinator_data(data):
+    """Malformed top-level coordinator data should render unknown."""
+    description = next(desc for desc in SENSOR_TYPES if desc.key == "stolen")
+    coordinator = MagicMock()
+    coordinator.data = data
+    coordinator.config_entry.entry_id = "entry-1"
+    coordinator.device_info = {}
+
+    entity = CowboyBinarySensor(coordinator, description)
+    assert entity.is_on is None
+
+    coordinator.data = {"stolen": True}
+    entity._update_state()
+    assert entity.is_on is True
+
+
+def test_update_binary_sensor_uses_initial_data():
+    """The legacy update sensor should also use the first refresh."""
+    coordinator = MagicMock()
+    coordinator.data = {
+        "firmware": {"name": "v4.22", "status": "deployed"},
+    }
+    coordinator.config_entry.entry_id = "entry-1"
+    coordinator.device_info = {"sw_version": "v4.21"}
+    description = CowboySensorEntityDescription(
+        key="update_available",
+        device_class=BinarySensorDeviceClass.UPDATE,
+    )
+
+    entity = CowboyUpdateBinarySensor(coordinator, description)
+    assert entity.is_on is True

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,9 +1,15 @@
 """Unit tests for sensor value functions."""
 from datetime import datetime
+from unittest.mock import MagicMock
 
 import pytest
 
-from custom_components.cowboy.sensor import SENSOR_TYPES, TRIPS_SENSOR_TYPES, _parse_iso
+from custom_components.cowboy.sensor import (
+    SENSOR_TYPES,
+    TRIPS_SENSOR_TYPES,
+    CowboySensor,
+    _parse_iso,
+)
 
 
 BIKE_DATA = {
@@ -28,6 +34,16 @@ BIKE_DATA = {
 def _value_fn(key):
     desc = next(d for d in SENSOR_TYPES if d.key == key)
     return desc.value_fn
+
+
+def _sensor(key: str, data: dict) -> tuple[CowboySensor, MagicMock]:
+    """Build a bike sensor backed by a mock coordinator."""
+    description = next(desc for desc in SENSOR_TYPES if desc.key == key)
+    coordinator = MagicMock()
+    coordinator.data = data
+    coordinator.config_entry.entry_id = "entry-1"
+    coordinator.device_info = {}
+    return CowboySensor(coordinator, description), coordinator
 
 
 def _trip_descriptions_by_key() -> dict:
@@ -98,6 +114,105 @@ def test_parse_iso_handles_none_and_bad_input():
     assert _parse_iso(None) is None
     assert _parse_iso("") is None
     assert _parse_iso("not-a-date") is None
+    assert _parse_iso(123) is None
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("total_distance", 7041),
+        ("total_duration", 2178000),
+        ("total_co2_saved", 1416351),
+        ("battery_state_of_charge", 49),
+        ("pcb_battery_state_of_charge", 86),
+    ],
+)
+def test_plain_sensor_uses_initial_data_and_clears_missing_values(key, value):
+    """Plain sensors should use the first refresh and not retain stale data."""
+    entity, coordinator = _sensor(key, {key: value})
+    assert entity.native_value == value
+
+    coordinator.data = {}
+    entity._update_state()
+    assert entity.native_value is None
+
+
+@pytest.mark.parametrize("data", [[1], "invalid"])
+def test_sensor_tolerates_malformed_coordinator_data(data):
+    """Malformed top-level coordinator data should render unknown."""
+    entity, coordinator = _sensor("total_distance", data)
+    assert entity.native_value is None
+
+    coordinator.data = {"total_distance": 42}
+    entity._update_state()
+    assert entity.native_value == 42
+
+
+def test_battery_calculations_use_matching_ride_mode():
+    """Battery calculations should use the matching full-battery range."""
+    assert _value_fn("remaining_range")(BIKE_DATA) == pytest.approx(21.567)
+    assert _value_fn("battery_health")(BIKE_DATA) == pytest.approx(51.1 / 51.35 * 100)
+
+
+def test_remaining_range_falls_back_to_top_level_autonomy():
+    """Remaining range should retain the existing top-level fallback."""
+    data = {"battery_state_of_charge": 50, "autonomy": 40}
+    assert _value_fn("remaining_range")(data) == 20
+
+
+def test_battery_calculations_skip_invalid_matching_autonomy():
+    """A later valid range should win over a malformed duplicate entry."""
+    data = BIKE_DATA | {
+        "autonomies": [
+            {"ride_mode": "static_eu", "full_battery_range": None},
+            {"ride_mode": "static_eu", "full_battery_range": 50},
+        ]
+    }
+    assert _value_fn("remaining_range")(data) == pytest.approx(21)
+    assert _value_fn("battery_health")(data) == pytest.approx(102.2)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {},
+        {"battery_state_of_charge": None},
+        {"battery_state_of_charge": 50, "autonomies": None},
+        {"battery_state_of_charge": 50, "autonomies": [None]},
+        {
+            "battery_state_of_charge": 50,
+            "last_ride_mode": "static_eu",
+            "autonomies": [{"ride_mode": "static_eu"}],
+        },
+    ],
+)
+def test_battery_calculations_tolerate_partial_data(data):
+    """Incomplete battery data should render unknown instead of raising."""
+    assert _value_fn("remaining_range")(data) is None
+    assert _value_fn("battery_health")(data) is None
+
+
+def test_battery_health_rejects_zero_full_range():
+    """A zero full range should not cause a division error."""
+    data = BIKE_DATA | {
+        "autonomies": [
+            {"ride_mode": "static_eu", "full_battery_range": 0},
+        ]
+    }
+    assert _value_fn("battery_health")(data) is None
+
+
+def test_nested_sensor_values_tolerate_malformed_data():
+    """Malformed optional nested objects should render unknown."""
+    assert _value_fn("auto_lock")({"pending_settings": "invalid"}) is None
+    assert _value_fn("displayed_speed")({"sku": {"features": "invalid"}}) is None
+
+
+def test_all_calculated_sensors_tolerate_empty_data():
+    """Every calculated bike sensor should tolerate an empty API payload."""
+    for description in SENSOR_TYPES:
+        if description.value_fn:
+            assert description.value_fn({}) is None, description.key
 
 
 def test_trip_value_functions_with_last_trip():


### PR DESCRIPTION
Bike sensors and binary sensors are added after the coordinator's first refresh, but they currently ignore that completed snapshot and wait for another update before populating state. Later responses also index optional fields directly, so a partial Cowboy payload can raise during an entity update and leave the previous value displayed as if it were current.

This initializes entity state from the latest coordinator data, clears values when fields disappear, and makes nested and calculated battery values tolerate missing or malformed input. Existing calculations and the fallback range behavior are preserved when valid data is available.

Testing:
- `ruff check .`
- `pytest tests/ -v --cov=custom_components.cowboy`